### PR TITLE
fix: [CI-21188]: Upgrade to Debian Bookworm to address CVEs

### DIFF
--- a/docker/Dockerfile-tmate
+++ b/docker/Dockerfile-tmate
@@ -1,7 +1,7 @@
 # ---------------------------------------------------------#
 #                   Build Tmate Binary                     #
 # ---------------------------------------------------------#
-FROM debian:bullseye-slim AS builder
+FROM debian:bookworm-slim AS builder
 
 WORKDIR /build
 
@@ -55,7 +55,7 @@ RUN ./tmate -V
 # ---------------------------------------------------------#
 #                   Create final image                     #
 # ---------------------------------------------------------#
-FROM debian:bullseye-slim
+FROM debian:bookworm-slim
 
 WORKDIR /binaries
 


### PR DESCRIPTION
- Upgrade from Debian Bullseye to Bookworm for security improvements
- Reduces vulnerabilities to only 3 (all unfixable/recent)
- Grype scan: 0 fixable vulnerabilities
- Trivy scan: 1 CRITICAL (will_not_fix MiniZip), 2 HIGH (no patch yet)
- Bookworm provides updated OpenSSL, zlib, and other packages